### PR TITLE
feat(defaultProps): fix issue with defaultProps warning for react 18

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ export default declare(({
     const resultArray = prop.value.expression.properties.map((property) => {
       let value;
 
-      if (/^\d$/gi.test(property.value.value)) {
+      if (/^\d*$/gi.test(property.value.value)) {
         value = t.numericLiteral(parseInt(property.value.value, 10));
       } else {
         value = t.stringLiteral(property.value.value);


### PR DESCRIPTION
remove defaultProps assignment in functional component, instead set them directly in function signature with default values